### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-componentmodel-dataannotations
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Jira issue link: [feng-722](https://workleap.atlassian.net/browse/feng-722)

This pull request makes a small update to the `.github/workflows/publish.yml` file to include a new configuration parameter for deployment.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R48): Added the `cortexEntityIdOrTag` parameter with the value `service-wl-componentmodel-dataannotations` to the `jobs:` section, enabling better identification of the deployment entity.